### PR TITLE
Allow seeing command lines with make V=1

### DIFF
--- a/base_rules
+++ b/base_rules
@@ -3,34 +3,34 @@ include $(DEVKITPPC)/base_tools
 #---------------------------------------------------------------------------------
 %.a:
 #---------------------------------------------------------------------------------
-	@echo $(notdir $@)
-	@rm -f $@
-	@$(AR) -rc $@ $^
+	$(SILENTMSG) $(notdir $@)
+	$(SILENTCMD)rm -f $@
+	$(SILENTCMD)$(AR) -rc $@ $^
 
 #---------------------------------------------------------------------------------
 %.o: %.cpp
-	@echo $(notdir $<)
-	@$(CXX) -MMD -MP -MF $(DEPSDIR)/$*.d $(CXXFLAGS) -c $< -o $@ $(ERROR_FILTER)
+	$(SILENTMSG) $(notdir $<)
+	$(SILENTCMD)$(CXX) -MMD -MP -MF $(DEPSDIR)/$*.d $(CXXFLAGS) -c $< -o $@ $(ERROR_FILTER)
 
 #---------------------------------------------------------------------------------
 %.o: %.c
-	@echo $(notdir $<)
-	@$(CC) -MMD -MP -MF $(DEPSDIR)/$*.d $(CFLAGS) -c $< -o $@ $(ERROR_FILTER)
+	$(SILENTMSG) $(notdir $<)
+	$(SILENTCMD)$(CC) -MMD -MP -MF $(DEPSDIR)/$*.d $(CFLAGS) -c $< -o $@ $(ERROR_FILTER)
 
 #---------------------------------------------------------------------------------
 %.o: %.m
-	@echo $(notdir $<)
-	@$(CC) -MMD -MP -MF $(DEPSDIR)/$*.d $(OBJCFLAGS) -c $< -o $@ $(ERROR_FILTER)
+	$(SILENTMSG) $(notdir $<)
+	$(SILENTCMD)$(CC) -MMD -MP -MF $(DEPSDIR)/$*.d $(OBJCFLAGS) -c $< -o $@ $(ERROR_FILTER)
 
 #---------------------------------------------------------------------------------
 %.o: %.s
-	@echo $(notdir $<)
-	@$(CC) -MMD -MP -MF $(DEPSDIR)/$*.d -x assembler-with-cpp $(ASFLAGS) -c $< -o $@ $(ERROR_FILTER)
+	$(SILENTMSG) $(notdir $<)
+	$(SILENTCMD)$(CC) -MMD -MP -MF $(DEPSDIR)/$*.d -x assembler-with-cpp $(ASFLAGS) -c $< -o $@ $(ERROR_FILTER)
 
 #---------------------------------------------------------------------------------
 %.o: %.S
-	@echo $(notdir $<)
-	@$(CC) -MMD -MP -MF $(DEPSDIR)/$*.d -x assembler-with-cpp $(ASFLAGS) -c $< -o $@ $(ERROR_FILTER)
+	$(SILENTMSG) $(notdir $<)
+	$(SILENTCMD)$(CC) -MMD -MP -MF $(DEPSDIR)/$*.d -x assembler-with-cpp $(ASFLAGS) -c $< -o $@ $(ERROR_FILTER)
 
 #---------------------------------------------------------------------------------
 # canned command sequence for binary data

--- a/base_tools
+++ b/base_tools
@@ -37,3 +37,14 @@ ISVC=$(or $(VCBUILDHELPER_COMMAND),$(MSBUILDEXTENSIONSPATH32),$(MSBUILDEXTENSION
 ifneq (,$(ISVC))
 	ERROR_FILTER	:=	2>&1 | sed -e 's/\(.[a-zA-Z]\+\):\([0-9]\+\):/\1(\2):/g'
 endif
+
+#---------------------------------------------------------------------------------
+# allow seeing compiler command lines with make V=1 (similar to autotools' silent)
+#---------------------------------------------------------------------------------
+ifeq ($(V),1)
+    SILENTMSG := @true
+    SILENTCMD :=
+else
+    SILENTMSG := @echo
+    SILENTCMD := @
+endif

--- a/gamecube_rules
+++ b/gamecube_rules
@@ -16,15 +16,15 @@ MACHDEP =  -DGEKKO -mogc -mcpu=750 -meabi -mhard-float
 
 #---------------------------------------------------------------------------------
 %.dol: %.elf
-	@echo output ... $(notdir $@)
-	@elf2dol $< $@
+	$(SILENTMSG) output ... $(notdir $@)
+	$(SILENTCMD)elf2dol $< $@
 
 #---------------------------------------------------------------------------------
 %.tpl : %.scf
-	@echo $(notdir $<)
-	@gxtexconv -s $< -d $(DEPSDIR)/$*.d -o $@
+	$(SILENTMSG) $(notdir $<)
+	$(SILENTCMD)gxtexconv -s $< -d $(DEPSDIR)/$*.d -o $@
 
 #---------------------------------------------------------------------------------
 %.elf:
-	@echo linking ... $(notdir $@)
-	@$(LD)  $^ $(LDFLAGS) $(LIBPATHS) $(LIBS) -o $@
+	$(SILENTMSG) linking ... $(notdir $@)
+	$(SILENTCMD)$(LD)  $^ $(LDFLAGS) $(LIBPATHS) $(LIBS) -o $@

--- a/wii_rules
+++ b/wii_rules
@@ -16,15 +16,15 @@ MACHDEP =  -DGEKKO -mrvl -mcpu=750 -meabi -mhard-float
 
 #---------------------------------------------------------------------------------
 %.dol: %.elf
-	@echo output ... $(notdir $@)
-	@elf2dol $< $@
+	$(SILENTMSG) output ... $(notdir $@)
+	$(SILENTCMD)elf2dol $< $@
 
 #---------------------------------------------------------------------------------
 %.tpl : %.scf
-	@echo $(notdir $<)
-	@gxtexconv -s $< -d $(DEPSDIR)/$*.d -o $@
+	$(SILENTMSG) $(notdir $<)
+	$(SILENTCMD)gxtexconv -s $< -d $(DEPSDIR)/$*.d -o $@
 
 #---------------------------------------------------------------------------------
 %.elf:
-	@echo linking ... $(notdir $@)
-	@$(LD)  $^ $(LDFLAGS) $(LIBPATHS) $(LIBS) -o $@
+	$(SILENTMSG) linking ... $(notdir $@)
+	$(SILENTCMD)$(LD)  $^ $(LDFLAGS) $(LIBPATHS) $(LIBS) -o $@


### PR DESCRIPTION
devkitPPC's makefiles by default silence all compiler commands, so I need to run `make` with `--trace` to actually see what it's doing (and using `--trace` for that feels like [cleaning windows with a cat](https://davejmurphy.com/a-slightly-surreal-rant/) 😉).

This change makes it so that when running `make` normally, you still get the nice silenced output as before, but one can run `make V=1` (similar to [automake silent rules](https://www.gnu.org/software/automake/manual/html_node/Automake-Silent-Rules.html)) to show the full compiler command lines instead. CMake has [something similar](https://cmake.org/cmake/help/v3.14/envvar/VERBOSE.html), but there it's called `VERBOSE=1`, and the devkitPPC tools feel more `make`-based, and so the automake approach feels a bit "closer".

The way this works is that by default, `$(SILENTMSG)` expands to `@echo` and `$(SILENTCMD)` expands to `@` (so it's like before), but if `V=1`, then `$(SILENTMSG)` expands to `@true` (which does not print anything, but calls `true` with the message, and `true` ignores any args it gets), and `$(SILENTCMD)` expands to the empty string (so the command is printed by `make`).

This is useful when wanting to figure out what the real compiler command is and helps in debugging (e.g. to check what the computed include directories end up being, etc..).