### PR TITLE
Fix bin2o

### DIFF
--- a/base_rules
+++ b/base_rules
@@ -37,9 +37,9 @@ include $(DEVKITPPC)/base_tools
 #---------------------------------------------------------------------------------
 define bin2o
 	bin2s -a 32 $< | $(AS) -o $(@)
-	echo "extern const u8" `(echo $(<F) | sed -e 's/^\([0-9]\)/_\1/' -e 's/[^A-Za-z0-9_]/_/g')`"_end[];" > `(echo $(<F) | tr . _)`.h
-	echo "extern const u8" `(echo $(<F) | sed -e 's/^\([0-9]\)/_\1/' -e 's/[^A-Za-z0-9_]/_/g')`"[];" >> `(echo $(<F) | tr . _)`.h
-	echo "extern const u32" `(echo $(<F) | sed -e 's/^\([0-9]\)/_\1/' -e 's/[^A-Za-z0-9_]/_/g')`_size";" >> `(echo $(<F) | tr . _)`.h
+	echo "extern const uint8_t" `(echo $(<F) | sed -e 's/^\([0-9]\)/_\1/' -e 's/[^A-Za-z0-9_]/_/g')`"_end[];" > `(echo $(<F) | tr . _)`.h
+	echo "extern const uint8_t" `(echo $(<F) | sed -e 's/^\([0-9]\)/_\1/' -e 's/[^A-Za-z0-9_]/_/g')`"[];" >> `(echo $(<F) | tr . _)`.h
+	echo "extern const size_t" `(echo $(<F) | sed -e 's/^\([0-9]\)/_\1/' -e 's/[^A-Za-z0-9_]/_/g')`_size";" >> `(echo $(<F) | tr . _)`.h
 endef
 
 

--- a/base_rules
+++ b/base_rules
@@ -37,7 +37,8 @@ include $(DEVKITPPC)/base_tools
 #---------------------------------------------------------------------------------
 define bin2o
 	bin2s -a 32 $< | $(AS) -o $(@)
-	echo "#include <stddef.h>" > `(echo $(<F) | tr . _)`.h
+	echo "#pragma once" > `(echo $(<F) | tr . _)`.h
+	echo "#include <stddef.h>" >> `(echo $(<F) | tr . _)`.h
 	echo "#include <stdint.h>" >> `(echo $(<F) | tr . _)`.h
 	echo "extern const uint8_t" `(echo $(<F) | sed -e 's/^\([0-9]\)/_\1/' -e 's/[^A-Za-z0-9_]/_/g')`"_end[];" >> `(echo $(<F) | tr . _)`.h
 	echo "extern const uint8_t" `(echo $(<F) | sed -e 's/^\([0-9]\)/_\1/' -e 's/[^A-Za-z0-9_]/_/g')`"[];" >> `(echo $(<F) | tr . _)`.h

--- a/base_rules
+++ b/base_rules
@@ -37,9 +37,10 @@ include $(DEVKITPPC)/base_tools
 #---------------------------------------------------------------------------------
 define bin2o
 	bin2s -a 32 $< | $(AS) -o $(@)
-	echo "extern const uint8_t" `(echo $(<F) | sed -e 's/^\([0-9]\)/_\1/' -e 's/[^A-Za-z0-9_]/_/g')`"_end[];" > `(echo $(<F) | tr . _)`.h
+	echo "#include <stddef.h>" > `(echo $(<F) | tr . _)`.h
+	echo "#include <stdint.h>" >> `(echo $(<F) | tr . _)`.h
+	echo "extern const uint8_t" `(echo $(<F) | sed -e 's/^\([0-9]\)/_\1/' -e 's/[^A-Za-z0-9_]/_/g')`"_end[];" >> `(echo $(<F) | tr . _)`.h
 	echo "extern const uint8_t" `(echo $(<F) | sed -e 's/^\([0-9]\)/_\1/' -e 's/[^A-Za-z0-9_]/_/g')`"[];" >> `(echo $(<F) | tr . _)`.h
 	echo "extern const size_t" `(echo $(<F) | sed -e 's/^\([0-9]\)/_\1/' -e 's/[^A-Za-z0-9_]/_/g')`_size";" >> `(echo $(<F) | tr . _)`.h
 endef
-
 


### PR DESCRIPTION
u8 and u32 doesn't exist anymore. So let's replace them with uint8_t and size_t.

Errors when using bin2o created header files without this patch:
`error: 'u32' does not name a type`
`error: 'u8' does not name a type`
