### PR TITLE
Changes for distro packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,13 @@ _PATCH	:= 1
 
 FILES	:=	base_rules base_tools gamecube_rules wii_rules
 
+PREFIX	?=	$(DEVKITPRO)/devkitPPC
+
 all:
 	@echo "use dist or install targets"
 
 install:
-	@cp -v $(FILES) $(DESTDIR)$(DEVKITPRO)/devkitPPC
+	@cp -v $(FILES) $(DESTDIR)$(PREFIX)
 
 dist:
 	@tar -cJf devkitppc-rules-$(_MAJOR).$(_MINOR).$(_PATCH).tar.xz $(FILES) Makefile

--- a/base_tools
+++ b/base_tools
@@ -63,7 +63,7 @@ endef
 # Generate compile commands
 #---------------------------------------------------------------------------------
 ifeq ($(GENERATE_COMPILE_COMMANDS),1)
-    ADD_COMPILE_COMMAND := @/opt/devkitpro/tools/bin/generate_compile_commands
+    ADD_COMPILE_COMMAND := @generate_compile_commands
 else
     ADD_COMPILE_COMMAND := @true
 endif


### PR DESCRIPTION
If devkitPPC isn't installed in the default location (e.g., a distro package), the hardcoded path would fail. `$DEVKITPRO/tools/bin` is already added to PATH in this same file anyway.