### PR TITLE
Removed spurious quotes on error messages.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ _PATCH	:= 1
 FILES	:=	base_rules base_tools gamecube_rules wii_rules
 
 all:
-	@echo "use dist or install targets"
+	$(error use dist or install targets)
 
 install:
 	@cp -v $(FILES) $(DESTDIR)$(DEVKITPRO)/devkitPPC

--- a/gamecube_rules
+++ b/gamecube_rules
@@ -1,5 +1,5 @@
 ifeq ($(strip $(DEVKITPPC)),)
-$(error "Please set DEVKITPPC in your environment. export DEVKITPPC=<path to>devkitPro/devkitPPC)
+$(error Please set DEVKITPPC in your environment. export DEVKITPPC=<path to>devkitPro/devkitPPC)
 endif
 
 include $(DEVKITPPC)/base_rules

--- a/wii_rules
+++ b/wii_rules
@@ -1,5 +1,5 @@
 ifeq ($(strip $(DEVKITPPC)),)
-$(error "Please set DEVKITPPC in your environment. export DEVKITPPC=<path to>devkitPro/devkitPPC)
+$(error Please set DEVKITPPC in your environment. export DEVKITPPC=<path to>devkitPro/devkitPPC)
 endif
 
 include $(DEVKITPPC)/base_rules


### PR DESCRIPTION
This PR removes the unbalanced opening quote in error messages.
It also changes the `@echo` line in the `Makefile` by a more appropriate use of `$(error)`.